### PR TITLE
Revert "improve connection handling"

### DIFF
--- a/Sieve.php
+++ b/Sieve.php
@@ -163,12 +163,6 @@ class Net_Sieve
     var $_bypassAuth = false;
 
     /**
-     * The timeout for the connection to the SIEVE server.
-     * @var int
-     */
-    var $_timeout = 5;
-
-    /**
      * Whether to use TLS if available.
      *
      * @var boolean
@@ -315,7 +309,7 @@ class Net_Sieve
             return PEAR::raiseError('Not currently in DISCONNECTED state', 1);
         }
 
-        $res = $this->_sock->connect($host, $port, false, ($this->_timeout?$this->_timeout:5), $options);
+        $res = $this->_sock->connect($host, $port, false, 5, $options);
         if (is_a($res, 'PEAR_Error')) {
             return $res;
         }


### PR DESCRIPTION
Reverts pear/Net_Sieve#2
This is undocumented (not even a changelog entry), incomplete (because it only sets the connection timeout, not the socket communication timeout), and unexposed (because there is no API to change the default - you have to extend the class for that).
