### PR TITLE
fix warning

### DIFF
--- a/Sieve.php
+++ b/Sieve.php
@@ -309,7 +309,11 @@ class Net_Sieve
         $this->_data['port'] = $port;
         $this->_useTLS       = $useTLS;
         if (is_array($options)) {
-            $this->_options = array_merge($this->_options, $options);
+            if (is_array($this->_options)) {
+                $this->_options = array_merge($this->_options, $options);
+            } else {
+                $this->_options = $options;
+            }
         }
 
         if (NET_SIEVE_STATE_DISCONNECTED != $this->_state) {


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1253940

     PHP Warning:  array_merge(): Argument #1 is not an array in /usr/share/pear/Net/Sieve.php on line 312

Notice: please note that this haven't be tested, blindly written (I have to simple way to test it)