### PR TITLE
Fixed typo in _authGSSAPI

### DIFF
--- a/Sieve.php
+++ b/Sieve.php
@@ -759,7 +759,7 @@ class Net_Sieve
 
         try {
             $ccache = new KRB5CCache();
-            $ccahe->open($this->_gssapiCN);
+            $ccache->open($this->_gssapiCN);
 
             $gssapicontext = new GSSAPIContext();
             $gssapicontext->acquireCredentials($ccache);


### PR DESCRIPTION
Typo "$ccahe" has introduced a bug in the _authGSSAPI function.

This should read "$ccache".

This pull request fixes this bug.