### PR TITLE
GSSAPI: make _gssapiCN optional

### DIFF
--- a/Sieve.php
+++ b/Sieve.php
@@ -751,13 +751,15 @@ class Net_Sieve
             return $this->_pear->raiseError('No Kerberos service principal set', 2);
         }
 
-        if ($this->_gssapiCN) {
+        if (!empty($this->_gssapiCN)) {
             putenv('KRB5CCNAME=' . $this->_gssapiCN);
         }
 
         try {
             $ccache = new KRB5CCache();
-            $ccache->open($this->_gssapiCN);
+            if (!empty($this->_gssapiCN)) {
+                $ccache->open($this->_gssapiCN);
+            }
 
             $gssapicontext = new GSSAPIContext();
             $gssapicontext->acquireCredentials($ccache);

--- a/Sieve.php
+++ b/Sieve.php
@@ -751,11 +751,9 @@ class Net_Sieve
             return $this->_pear->raiseError('No Kerberos service principal set', 2);
         }
 
-        if (!$this->_gssapiCN) {
-            return $this->_pear->raiseError('No Kerberos service CName set', 2);
+        if ($this->_gssapiCN) {
+            putenv('KRB5CCNAME=' . $this->_gssapiCN);
         }
-
-        putenv('KRB5CCNAME=' . $this->_gssapiCN);
 
         try {
             $ccache = new KRB5CCache();


### PR DESCRIPTION
A small fix to GSSAPI support. GSSAPI may be used without _gssapiCN (KRB5CCNAME), since MIT/Heimdal libs have a default value for credentials cache.
https://web.mit.edu/kerberos/krb5-1.12/doc/basic/ccache_def.html#default-ccache-name