### PR TITLE
Add missing comma character after user

### DIFF
--- a/Sieve.php
+++ b/Sieve.php
@@ -971,7 +971,7 @@ class Net_Sieve
             $euser = $user;
         }
 
-        $auth = base64_encode("n,a=$euser\001auth=$token\001\001");
+        $auth = base64_encode("n,a=$euser,\001auth=$token\001\001");
         return $this->_sendCmd("AUTHENTICATE \"OAUTHBEARER\" \"$auth\"");
     }
 


### PR DESCRIPTION
According to RFC7628, "a" parameter value ends with ",^A"